### PR TITLE
Add escaping client arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.4.0
+- Added automatically escaping & wrapping arguments in double quotation marks in client calls 
+  - This is a breaking change and requires any manually wrapped arguments and escaped  characters to be updated (Remove wrapping quotes and escaping backslashes from client calls)
+
 ## 0.3.2
 - Fixed `getvol` threw an exception when there was no mixer
-  - Returns `null` now.
+  - Returns `null` now
 
 ## 0.3.1
 - Fixed incoming mpd message sometimes got parsed incorrectly, causing responses to be associated with the wrong request
@@ -13,7 +17,7 @@
   - Called with the event that is sent to MPD
 - Fixed multiple values for a tag in a song didn't get parsed correctly
 - Fixed `readpicture` threw an exception when the current song had no picture
-  - Returns `null` now.
+  - Returns `null` now
 - Removed `MpdValue` union type in favor of a `List<String>` to store the values of a key in `MpdResponse`
 
 ## 0.2.0

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,6 @@
 include: package:lints/recommended.yaml
 
-linter:
-  rules:
-    non_constant_identifier_names: false
+analyzer:
+  exclude:
+    - lib/**.freezed.dart
+    - lib/**.g.dart

--- a/lib/dart_mpd.dart
+++ b/lib/dart_mpd.dart
@@ -1,6 +1,6 @@
 library dart_mpd;
 
-export 'src/client.dart';
+export 'src/client/client.dart';
 export 'src/connection.dart';
 export 'src/connection_details.dart';
 export 'src/exception.dart';

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1307,6 +1307,8 @@ class MpdClient {
   }
 }
 
+// TODO: move to client_utils file and write tests
+
 String _buildCmd(String cmd, List<Object?> args) {
   if (args.isEmpty) return cmd;
 
@@ -1319,19 +1321,37 @@ String _formatArgs(List<Object?> args) {
   final filtered = args.where((e) => e != null).toList();
 
   for (var i = 0; i < filtered.length; ++i) {
-    final arg = filtered[i];
+    var arg = filtered[i];
 
     if (arg is bool) {
-      buffer.write(arg ? 1 : 0);
+      arg = arg ? '1' : '0';
     } else if (arg is MpdSingle) {
-      buffer.write(arg.toValue());
+      arg = arg.toValue();
     } else if (arg is Enum) {
-      buffer.write(arg.name);
-    } else {
-      buffer.write(arg);
+      arg = arg.name;
     }
 
+    arg = _escapeArg('$arg');
+    buffer.write('"$arg"');
+
     if (i != filtered.length - 1) buffer.write(' ');
+  }
+
+  return buffer.toString();
+}
+
+/// Escapes the argument.
+///
+/// See https://mpd.readthedocs.io/en/stable/protocol.html#escaping-string-values.
+String _escapeArg(String arg) {
+  final buffer = StringBuffer();
+
+  for (final char in arg.split('')) {
+    if (char == '"' || char == r'\\') {
+      buffer.write(r'\\');
+    }
+
+    buffer.write(char);
   }
 
   return buffer.toString();

--- a/lib/src/client/client_utils.dart
+++ b/lib/src/client/client_utils.dart
@@ -1,0 +1,49 @@
+import 'package:dart_mpd/dart_mpd.dart';
+
+String buildClientCmd(String cmd, List<Object?> args) {
+  if (args.isEmpty) return cmd;
+
+  final formattedArgs = _formatArgs(args);
+  if (formattedArgs.isEmpty) return cmd;
+
+  return '$cmd $formattedArgs';
+}
+
+String _formatArgs(List<Object?> args) {
+  final buffer = StringBuffer();
+
+  final filtered = args.where((e) => e != null).toList();
+
+  for (var i = 0; i < filtered.length; ++i) {
+    var arg = filtered[i];
+
+    if (arg is bool) {
+      arg = arg ? '1' : '0';
+    } else if (arg is MpdSingle) {
+      arg = arg.toValue();
+    } else if (arg is Enum) {
+      arg = arg.name;
+    }
+
+    arg = _escapeArg('$arg');
+    buffer.write('"$arg"');
+
+    if (i != filtered.length - 1) buffer.write(' ');
+  }
+
+  return buffer.toString();
+}
+
+String _escapeArg(String arg) {
+  final buffer = StringBuffer();
+
+  for (final char in arg.split('')) {
+    if (char == '"' || char == r'\') {
+      buffer.write(r'\');
+    }
+
+    buffer.write(char);
+  }
+
+  return buffer.toString();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_mpd
 description: a dart package which implements the MPD protocol. https://www.musicpd.org/
-version: 0.3.2
+version: 0.4.0
 repository: https://github.com/robertodoering/dart_mpd
 
 environment:

--- a/test/client_utils_test.dart
+++ b/test/client_utils_test.dart
@@ -1,0 +1,63 @@
+import 'package:dart_mpd/dart_mpd.dart';
+import 'package:dart_mpd/src/client/client_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('$buildClientCmd', () {
+    test('returns the cmd when no args have been provided', () {
+      final cmd = buildClientCmd('status', []);
+
+      expect(cmd, 'status');
+    });
+
+    test('returns the cmd when provided args are `null`', () {
+      final cmd = buildClientCmd('shuffle', [null]);
+
+      expect(cmd, 'shuffle');
+    });
+
+    test('wraps args in quotation marks', () {
+      final cmd = buildClientCmd('cmd', ['arg1', 'arg two']);
+
+      expect(cmd, 'cmd "arg1" "arg two"');
+    });
+
+    test('formats `bool` args', () {
+      final cmd = buildClientCmd('cmd', [true, false]);
+
+      expect(cmd, 'cmd "1" "0"');
+    });
+
+    test('formats `MpdSingle` args by using its `toValue` value', () {
+      final args = [MpdSingle.enabled, MpdSingle.disabled, MpdSingle.oneshot];
+      final cmd = buildClientCmd('cmd', args);
+
+      expect(
+        args.length,
+        MpdSingle.values.length,
+        reason: 'not all values of `MpdSingle` are tested',
+      );
+
+      expect(cmd, 'cmd "1" "0" "oneshot"');
+    });
+
+    test('formats `Enum` args by using their `name`', () {
+      final cmd = buildClientCmd(
+        'cmd',
+        [ReplayGainMode.auto, MpdSubsystem.database],
+      );
+
+      expect(cmd, 'cmd "auto" "database"');
+    });
+
+    test('escapes args', () {
+      final cmd = buildClientCmd(
+        'find',
+        // finding an artist named foo'bar"
+        [r'''(Artist == "foo\'bar\"")'''],
+      );
+
+      expect(cmd, r'''find "(Artist == \"foo\\'bar\\\"\")"''');
+    });
+  });
+}


### PR DESCRIPTION
This PR adds automatically wrapping arguments in quotation marks and escaping quotation marks & backslashes in arguments.

Any calls prior to this that added wrapping quotation marks or escaped any characters need to be updated.

closes  #3